### PR TITLE
Add Spring Boot product API skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# rtt-products
+# RTT Products
+
+Spring Boot API for managing products and customer returns.
+
+## Build
+
+Requires Java 17 and Maven.
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,50 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.1.5</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>rtt-products</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>rtt-products</name>
+    <description>RTT Products API</description>
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/rttproducts/RttProductsApplication.java
+++ b/src/main/java/com/example/rttproducts/RttProductsApplication.java
@@ -1,0 +1,12 @@
+package com.example.rttproducts;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RttProductsApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(RttProductsApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/rttproducts/product/Product.java
+++ b/src/main/java/com/example/rttproducts/product/Product.java
@@ -1,0 +1,40 @@
+package com.example.rttproducts.product;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String description;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/rttproducts/product/ProductController.java
+++ b/src/main/java/com/example/rttproducts/product/ProductController.java
@@ -1,0 +1,55 @@
+package com.example.rttproducts.product;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/products")
+public class ProductController {
+
+    private final ProductRepository repository;
+
+    public ProductController(ProductRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping
+    public List<Product> list() {
+        return repository.findAll();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Product create(@RequestBody Product product) {
+        return repository.save(product);
+    }
+
+    @GetMapping("/{id}")
+    public Product get(@PathVariable Long id) {
+        return repository.findById(id).orElseThrow();
+    }
+
+    @PutMapping("/{id}")
+    public Product update(@PathVariable Long id, @RequestBody Product product) {
+        Product existing = repository.findById(id).orElseThrow();
+        existing.setName(product.getName());
+        existing.setDescription(product.getDescription());
+        return repository.save(existing);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        repository.deleteById(id);
+    }
+}

--- a/src/main/java/com/example/rttproducts/product/ProductRepository.java
+++ b/src/main/java/com/example/rttproducts/product/ProductRepository.java
@@ -1,0 +1,6 @@
+package com.example.rttproducts.product;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/example/rttproducts/returning/ProductReturn.java
+++ b/src/main/java/com/example/rttproducts/returning/ProductReturn.java
@@ -1,0 +1,45 @@
+package com.example.rttproducts.returning;
+
+import com.example.rttproducts.product.Product;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class ProductReturn {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private Product product;
+
+    private String reason;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/src/main/java/com/example/rttproducts/returning/ProductReturnController.java
+++ b/src/main/java/com/example/rttproducts/returning/ProductReturnController.java
@@ -1,0 +1,44 @@
+package com.example.rttproducts.returning;
+
+import java.util.List;
+
+import com.example.rttproducts.product.Product;
+import com.example.rttproducts.product.ProductRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/returns")
+public class ProductReturnController {
+
+    private final ProductReturnRepository returnRepository;
+    private final ProductRepository productRepository;
+
+    public ProductReturnController(ProductReturnRepository returnRepository,
+                                   ProductRepository productRepository) {
+        this.returnRepository = returnRepository;
+        this.productRepository = productRepository;
+    }
+
+    @GetMapping
+    public List<ProductReturn> list() {
+        return returnRepository.findAll();
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ProductReturn create(@RequestBody CreateReturnRequest request) {
+        Product product = productRepository.findById(request.productId()).orElseThrow();
+        ProductReturn pr = new ProductReturn();
+        pr.setProduct(product);
+        pr.setReason(request.reason());
+        return returnRepository.save(pr);
+    }
+
+    public record CreateReturnRequest(Long productId, String reason) {}
+}

--- a/src/main/java/com/example/rttproducts/returning/ProductReturnRepository.java
+++ b/src/main/java/com/example/rttproducts/returning/ProductReturnRepository.java
@@ -1,0 +1,6 @@
+package com.example.rttproducts.returning;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductReturnRepository extends JpaRepository<ProductReturn, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/com/example/rttproducts/RttProductsApplicationTests.java
+++ b/src/test/java/com/example/rttproducts/RttProductsApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.rttproducts;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class RttProductsApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Spring Boot project skeleton for products and returns
- implement REST controllers, JPA entities, and repositories
- configure in-memory H2 database and basic test scaffold

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688f9c111f488323bb95a7cf29c1a6a0